### PR TITLE
Add ionic build command to Android workflow

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -32,7 +32,9 @@ jobs:
 
       - name: Build Android app
         working-directory: my-softskills-app
-        run: npx cap sync android
+        run: |
+          npx cap sync android
+          ls -l android/app/build/outputs/apk/debug/
 
       - name: Run tests
         working-directory: my-softskills-app

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,3 +1,4 @@
+
 name: Android Build
 on:
   push:
@@ -33,6 +34,7 @@ jobs:
       - name: Build Android app
         working-directory: my-softskills-app
         run: |
+          npm run build
           npx cap sync android
           ls -l android/app/build/outputs/apk/debug/
 
@@ -56,5 +58,3 @@ jobs:
         with:
           name: android-app
           path: my-softskills-app/android/app/build/outputs/apk/debug/app-debug.apk
-
-


### PR DESCRIPTION
This pull request adds the `npm run build` command before `npx cap sync android` in the Android build workflow to ensure the Ionic project is built before syncing with Capacitor. This should resolve issues with APK generation.